### PR TITLE
Corrected wrong bin 525320

### DIFF
--- a/iin-user-contributions.csv
+++ b/iin-user-contributions.csv
@@ -3565,3 +3565,4 @@ iin,card_brand,card_sub_brand,card_type,card_category,country_code,bank_name,ban
 622305,CHINA UNION PAY,,DEBIT,,CN,BANK OF NANJING,www.njcb.com.cn,+86 96400,Nanjing
 622202,CHINA UNION PAY,,DEBIT,,CN,ICBC,www.icbc.com.cn,+86 95588,Beijing
 622698,CHINA UNION PAY,,DEBIT,,CN,CHINA CITIC BANK,bank.ecitic.com,+86 95558,
+525320,MASTERCARD,ELECTRON,CREDIT,,BR,ITAU UNIBANCO S/A,www.itau.com.br,+55 11 3003 3030,Sao Paulo


### PR DESCRIPTION
Bin 525320 corrected, matches the data reported by http://www.binbase.com/search.html

Current data:
{"bin":"525320","brand":"MASTERCARD","sub_brand":"","country_code":"NO","country_name":"Norway","bank":"EUROPAY NORGE, A.S.","card_type":"CREDIT","card_category":"","latitude":"62","longitude":"10","query_time":"313.547us"}
