### PR TITLE
Update iin-user-contributions.csv

### DIFF
--- a/iin-user-contributions.csv
+++ b/iin-user-contributions.csv
@@ -1,4 +1,5 @@
 iin,card_brand,card_sub_brand,card_type,card_category,country_code,bank_name,bank_url,bank_phone,bank_city
+360324,DINERS CLUB INTERNATIONAL,,CREDIT,STANDARD,CO,Banco Davivienda S.A.,www.davivienda.com,+57 1 3383838,Bogotá D.C.
 370245,AMERICAN EXPRESS,,CREDIT,PRESTIGE,VE,BANESCO BANCO UNIVERSAL S.A.,www.banesco.com,+58 212 501 11 11,CARACAS
 410131,VISA,ELECTRON,DEBIT,,QZ,PROCREDIT BANK,www.procreditbank-kos.com,+381 38 555 555,Prishtine
 410687,VISA,ELECTRON,DEBIT,,QZ,RAIFFEISEN BANK,www.raiffeisen-kosovo.com,+381 38 222 222,Prishtine


### PR DESCRIPTION
Add record for Diners Club International credit card issued in Colombia by Banco Davivienda S.A (Currently Banco Davivienda is the unique financial institution in Colombia who issue this brand of credit card)
