### PR TITLE
Inserting range 526879 - Qantas Money

### DIFF
--- a/ranges.csv
+++ b/ranges.csv
@@ -5075,6 +5075,7 @@ iin_start,iin_end,number_length,number_luhn,scheme,brand,type,prepaid,country,ba
 526835,,,,mastercard,,credit,,US,CAPITAL ONE,,,8004194959,
 526851,,,,mastercard,,credit,,MY,CITIBANK,,,60323830000,
 526863,,,,mastercard,,credit,,BR,ITAU,,,CENTRAL FAX: 4163696305,
+526879,,,,mastercard,,credit,,AU,QANTAS MONEY,,www.qantasmoney.com,+61 1300 992 700,
 526948,,,,mastercard,,credit,,NO,Nordea,,,4791506001,
 526973,,,,mastercard,,credit,,TR,,,,,
 527368,,,,mastercard,,debit,,US,GREEN DOT,,,8779374098,


### PR DESCRIPTION
This card is provided by Citibank Australia, so bank name could also be Citibank.
The website www.qantasmoney.com clearly shows a card with this BIN number listed.