### PR TITLE
Update ranges.csv

### DIFF
--- a/ranges.csv
+++ b/ranges.csv
@@ -5550,7 +5550,7 @@ iin_start,iin_end,number_length,number_luhn,scheme,brand,type,prepaid,country,ba
 548827,,,,mastercard,,credit,,BR,CAIXA ECONOMICA FEDERAL,,,08007284455,
 548853,,,,mastercard,,credit,,US,KEYBANK,,,8005392968,
 548897,,,,mastercard,,credit,,US,CAPITAL ONE,,,5032934037,
-548901,,,,mastercard,,credit,,ES,SANTANDER CENTRAL HISPANO,,,902242424,
+548901,,,,mastercard,,debit,,ES,SANTANDER CENTRAL HISPANO,,,902242424,
 548953,,,,mastercard,,credit,,IS,ISLANDSBANKI,,,4404000,
 548984,,,,mastercard,,credit,,BR,ITAU,,,551140014848,
 548985,,,,mastercard,,credit,,BR,ITAU,,,556232754234,


### PR DESCRIPTION
Card range 548901 belongs to debit cards from Santander Bank, as its brand name is "Standard Immediate Debit" as it clearly states on your website.