### PR TITLE
Uptade range.csv - SWEDBANK AB

### DIFF
--- a/ranges.csv
+++ b/ranges.csv
@@ -4875,6 +4875,7 @@ iin_start,iin_end,number_length,number_luhn,scheme,brand,type,prepaid,country,ba
 516724,,,,mastercard,,debit,,US,LENNOX EMPLOYEES CREDIT UNION,,,61 292263268,
 516746,,,,mastercard,,debit,,GE,Bank of Georgia,,www.bankofgeorgia.ge,+995 32 244 44 44,Tbilisi
 516795,,,,mastercard,,debit,,IT,INTESA SANPAOLO,,,61 292263268,
+516815,,,,mastercard,,debit,,SE,SWEDBANK AB,,www.swedbank.se,084111011,
 516943,,,,mastercard,,debit,,TR,GARANTI,,,4440333,
 516968,,,,mastercard,,debit,,IE,KBC Bank Ireland,,www.kbc.ie,+35316347963,Dublin
 517012,,,,mastercard,,debit,,DK,Sparekassen Kronjylland,,,22148774,


### PR DESCRIPTION
adding 516815 as SWEDBANK AB (currently it returns something weird)
This sites returns SWEDBANK for '516815'
https://www.bindb.com
https://www.bincodes.com
BinList [https://lookup.binlist.net/516815] returns:
"WESTPAC BANKING CORPORATION" - Australia